### PR TITLE
fix: mysql数据库初始化报错

### DIFF
--- a/server/service/sys_initdb.go
+++ b/server/service/sys_initdb.go
@@ -87,7 +87,7 @@ func InitDB(conf request.InitDB) error {
 		conf.Port = "3306"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/", conf.UserName, conf.Password, conf.Host, conf.Port)
-	createSql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;", conf.DBName)
+	createSql := fmt.Sprintf("CREATE DATABASE /*!32312 IF NOT EXISTS*/ `%s` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;", conf.DBName)
 	if err := createTable(dsn, "mysql", createSql); err != nil {
 		return err
 	}


### PR DESCRIPTION
mysql 5.7 初始化异常
 CREATE DATABASE IF NOT EXISTS y-admin DEFAULT CHARSET SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci; 

1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-admin DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_general_ci' at line 1, Time: 0.013000s